### PR TITLE
Add os.chdir(dir_with_xmls) to last cell

### DIFF
--- a/validate_EDTF_from_XML.ipynb
+++ b/validate_EDTF_from_XML.ipynb
@@ -86,6 +86,7 @@
     }
    ],
    "source": [
+    "os.chdir(dir_with_xmls)",
     "listofxml = os.listdir(dir_with_xmls)\n",
     "print(\"--- Validating directory {} ---\".format(dir_with_xmls))\n",
     "for xml in listofxml:\n",


### PR DESCRIPTION
os.chdir(dir_with_xmls) deals with the situation where the XML's are not situated in the same folder as the jupyter notebook.